### PR TITLE
Page, Region, Field are all instance classes and hence need to link t…

### DIFF
--- a/src/main/java/org/awiki/kamikaze/summit/domain/Field.java
+++ b/src/main/java/org/awiki/kamikaze/summit/domain/Field.java
@@ -42,6 +42,8 @@ public class Field implements java.io.Serializable
   //private String              defaultValue;
   private String              notes;
   private Set<RegionField>    regionFields = new HashSet<RegionField>(0);
+  private Template             template;
+  
 
   public Field()
   {
@@ -170,6 +172,17 @@ public class Field implements java.io.Serializable
   public void setRegionFields(Set<RegionField> regionFields)
   {
     this.regionFields = regionFields;
+  }
+
+  
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "template_id", nullable = false)
+  public Template getTemplate() {
+    return template;
+  }
+
+  public void setTemplate(Template template) {
+    this.template = template;
   }
 
 }

--- a/src/main/java/org/awiki/kamikaze/summit/domain/Page.java
+++ b/src/main/java/org/awiki/kamikaze/summit/domain/Page.java
@@ -33,7 +33,7 @@ public class Page implements java.io.Serializable
 
   //changed definition
   private String               name;
-  //private Template             template;
+  private Template             template;
   
   public Page()
   {
@@ -107,7 +107,7 @@ public class Page implements java.io.Serializable
     this.name = name;
   }
 
-  /*
+  
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "template_id", nullable = false)
   public Template getTemplate() {
@@ -117,5 +117,5 @@ public class Page implements java.io.Serializable
   public void setTemplate(Template template) {
     this.template = template;
   }
-*/
+
 }

--- a/src/main/java/org/awiki/kamikaze/summit/domain/Region.java
+++ b/src/main/java/org/awiki/kamikaze/summit/domain/Region.java
@@ -44,6 +44,8 @@ public class Region implements java.io.Serializable
   
   private Set<PageRegion>    pageRegions  = new HashSet<PageRegion>(0);
   private Set<RegionField>   regionFields = new HashSet<RegionField>(0);
+  private Template           template;
+  
 
   public Region()
   {
@@ -161,5 +163,17 @@ public class Region implements java.io.Serializable
   {
     this.codeSourceType = codeSourceType;
   }
+  
+  
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "template_id", nullable = false)
+  public Template getTemplate() {
+    return template;
+  }
+
+  public void setTemplate(Template template) {
+    this.template = template;
+  }
+
 
 }

--- a/src/main/java/org/awiki/kamikaze/summit/domain/Template.java
+++ b/src/main/java/org/awiki/kamikaze/summit/domain/Template.java
@@ -7,6 +7,8 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
@@ -22,6 +24,10 @@ public class Template  implements java.io.Serializable {
   private long       id;
   private String     className;
   private String     source;
+  private String     mimeType;
+  
+  private Template   parent; // associated parent template (self-referencing join)
+  private Set<Template> children = new HashSet<>(0); // associated child templates (self-referencing join)
   
   //private Set<Page>  pages = new HashSet<>(0);
 
@@ -29,11 +35,14 @@ public class Template  implements java.io.Serializable {
   {
   }
 
-  public Template(long id, final String name,final String bodySource)
+  public Template(long id, final String name,final String bodySource, final String mimeType,Template parent, Set<Template> children)
   {
     this.id = id;
+    this.parent = parent;
     this.className = name;
     this.source = bodySource;
+    this.mimeType = mimeType;
+    this.children = children;
   }
 
 
@@ -69,6 +78,39 @@ public class Template  implements java.io.Serializable {
   {
     this.source = bodySource;
   }
+
+  @Column(name = "mime_type", nullable = true)
+  public String getMimeType()
+  {
+    return mimeType;
+  }
+
+  public void setMimeType(String mimeType)
+  {
+    this.mimeType = mimeType;
+  }
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id", nullable = false)
+  public Template getParent() {
+    return parent;
+  }
+
+  public void setParent(Template parent) {
+    this.parent = parent;
+  }
+
+  @OneToMany(fetch = FetchType.LAZY, mappedBy = "parent")
+  public Set<Template> getChildren()
+  {
+    return children;
+  }
+
+  public void setChildren(Set<Template> children)
+  {
+    this.children = children;
+  }
+
 
 
 }

--- a/src/main/java/org/awiki/kamikaze/summit/dto/entry/FieldDto.java
+++ b/src/main/java/org/awiki/kamikaze/summit/dto/entry/FieldDto.java
@@ -26,6 +26,7 @@ public class FieldDto implements PageItem<String> {
   private String                defaultValueSource; // actual SQL/HTML/JSP code
   private String                notes;
   private Set<RegionFieldDto>   regionFields = new HashSet<>(0);
+  private TemplateDto           template;
   
   private PostProcessedFieldContentDto postProcessedSource;
   private PostProcessedFieldContentDto postProcessedDefaultValue;
@@ -152,6 +153,20 @@ public class FieldDto implements PageItem<String> {
   public List<PageItem<String>> getSubPageItems()
   {
     return new ArrayList<>(0);
+  }
+  public TemplateDto getTemplate()
+  {
+    return template;
+  }
+  public void setTemplate(TemplateDto template)
+  {
+    this.template = template;
+  }
+
+  @Override
+  public TemplateDto getTemplateDto()
+  {
+    return getTemplate();
   }
   
 }

--- a/src/main/java/org/awiki/kamikaze/summit/dto/entry/PageDto.java
+++ b/src/main/java/org/awiki/kamikaze/summit/dto/entry/PageDto.java
@@ -82,5 +82,10 @@ public class PageDto implements PageItem<String> {
     return regions;
   }
   
-  
+  @Override
+  public TemplateDto getTemplateDto()
+  {
+    return getTemplate();
+  }
+
 }

--- a/src/main/java/org/awiki/kamikaze/summit/dto/entry/PageItem.java
+++ b/src/main/java/org/awiki/kamikaze/summit/dto/entry/PageItem.java
@@ -25,6 +25,12 @@ public interface PageItem<T> // Where T is the processed source type
    */
   public Collection<PageItem<T>> getSubPageItems();
   
+  /**
+   * If the instance of this pageItem has an associated template, then return it.
+   * @return TemplateDto
+   */
+  public TemplateDto getTemplateDto();
+  
   public void setProcessedSource(T t); //unsure if needed
 
   /**

--- a/src/main/java/org/awiki/kamikaze/summit/dto/entry/RegionDto.java
+++ b/src/main/java/org/awiki/kamikaze/summit/dto/entry/RegionDto.java
@@ -24,6 +24,7 @@ public class RegionDto implements PageItem<String> {
   
   private Set<PageRegionDto>    pageRegions  = new HashSet<>(0);
   private Set<RegionFieldDto>   regionFields = new LinkedHashSet<>(0);
+  private TemplateDto           template;
   
   ////// post-processed page items, not mapped.
   private Collection<PageItem<String>> subPageItems = new LinkedHashSet<>(0);
@@ -113,4 +114,19 @@ public class RegionDto implements PageItem<String> {
     // TODO Auto-generated method stub
     return null;
   }
+  public TemplateDto getTemplate()
+  {
+    return template;
+  }
+  public void setTemplate(TemplateDto template)
+  {
+    this.template = template;
+  }
+
+  @Override
+  public TemplateDto getTemplateDto()
+  {
+    return getTemplate();
+  }
+
 }

--- a/src/main/java/org/awiki/kamikaze/summit/dto/entry/TemplateDto.java
+++ b/src/main/java/org/awiki/kamikaze/summit/dto/entry/TemplateDto.java
@@ -8,6 +8,10 @@ public class TemplateDto {
   private long       id;
   private String     className;
   private String     source;
+  private String     mimeType;
+  
+  private TemplateDto parent;
+  private Set<TemplateDto> children = new HashSet<>(0);
   
   private Set<PageDto> pages = new HashSet<>(0);
   
@@ -44,4 +48,32 @@ public class TemplateDto {
     this.pages = pages;
   }
 
+  public String getMimeType()
+  {
+    return mimeType;
+  }
+
+  public void setMimeType(String mimeType)
+  {
+    this.mimeType = mimeType;
+  }
+
+  public TemplateDto getParent() {
+    return parent;
+  }
+
+  public void setParent(TemplateDto parent) {
+    this.parent = parent;
+  }
+
+  public Set<TemplateDto> getChildren()
+  {
+    return children;
+  }
+
+  public void setChildren(Set<TemplateDto> children)
+  {
+    this.children = children;
+  }
+  
 }

--- a/src/main/java/org/awiki/kamikaze/summit/service/PageRenderingServiceImpl.java
+++ b/src/main/java/org/awiki/kamikaze/summit/service/PageRenderingServiceImpl.java
@@ -110,7 +110,8 @@ public class PageRenderingServiceImpl implements PageRenderingService {
     
     log.info(Thread.currentThread().getStackTrace()[1].getMethodName().toString() + ": processRegionsForRender took: " + (end - start) / 1000000 + "ms");
     
-    //now run each page item through the formatters to apply each template
+    //now start at the page formatter, which will coordinate
+    // all sub-page-items through their respective formatters to apply each template
     final StringBuilder builder = new StringBuilder();
     start = System.nanoTime();
     FormatterService service = sourceFormatters.getFormatterService(PageDto.class.getCanonicalName());
@@ -160,6 +161,7 @@ public class PageRenderingServiceImpl implements PageRenderingService {
       if(REGION_TYPE_REPORT.equals(regionDto.getCodeRegionType()) ) {
         ReportSourceProcessorService reportService = (ReportSourceProcessorService) sourceProcessors.getSourceProcessorService(regionDto.getCodeSourceType());
         SourceProcessorResultTable resultTable = reportService.querySource(regionDto.getSource().iterator().next(), null);
+        resultTable.setTemplateDto(regionDto.getTemplateDto());
         regionItems.add(resultTable);
       }
       else {

--- a/src/main/java/org/awiki/kamikaze/summit/service/formatter/GenericFormatterServiceImpl.java
+++ b/src/main/java/org/awiki/kamikaze/summit/service/formatter/GenericFormatterServiceImpl.java
@@ -13,6 +13,7 @@ import org.awiki.kamikaze.summit.dto.entry.FieldDto;
 import org.awiki.kamikaze.summit.dto.entry.PageDto;
 import org.awiki.kamikaze.summit.dto.entry.PageItem;
 import org.awiki.kamikaze.summit.dto.entry.RegionDto;
+import org.awiki.kamikaze.summit.dto.entry.TemplateDto;
 import org.awiki.kamikaze.summit.repository.TemplateRepository;
 import org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,8 +48,7 @@ public class GenericFormatterServiceImpl implements GenericFormatterService
   @Override
   public StringBuilder format(StringBuilder builder, PageItem<String> item, int insertAt)
   { 
-    //FIXME: HACK: /* Change this to using template instance, once we have implemented it */
-    Template template = repository.findByClassName(item.getClass().getCanonicalName());
+    final TemplateDto template = item.getTemplateDto(); 
     int nextInsertAt = template.getSource().indexOf(REPLACEMENT_VARIABLE.toString()) + insertAt;
     builder.insert(insertAt, template.getSource().replace(REPLACEMENT_VARIABLE.toString(), item.getProcessedSource() == null ? "" : item.getProcessedSource()));
 

--- a/src/main/java/org/awiki/kamikaze/summit/service/processor/result/SourceProcessorResultTable.java
+++ b/src/main/java/org/awiki/kamikaze/summit/service/processor/result/SourceProcessorResultTable.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.apache.commons.collections.iterators.ArrayListIterator;
 import org.awiki.kamikaze.summit.dto.entry.PageItem;
+import org.awiki.kamikaze.summit.dto.entry.TemplateDto;
 import org.awiki.kamikaze.summit.service.formatter.Formattable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,8 @@ import org.slf4j.LoggerFactory;
 public class SourceProcessorResultTable implements PageItem<String>, Formattable<org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.Row>
 {  
   private static final Logger logger = LoggerFactory.getLogger(SourceProcessorResultTable.class);
+  
+  private TemplateDto templateDto;
   
   /*
    * This class only knows about the list of rows it contains.
@@ -152,6 +155,8 @@ public class SourceProcessorResultTable implements PageItem<String>, Formattable
   
   
   public class Row implements PageItem<String>, Iterable<Cell>, Formattable<String> {
+    private TemplateDto templateDto;
+    
     private List<Cell> cells = new ArrayList<>();
 
     public Row() { }
@@ -241,11 +246,31 @@ public class SourceProcessorResultTable implements PageItem<String>, Formattable
       // TODO Auto-generated method stub
       return null;
     }
+
+    @Override
+    public TemplateDto getTemplateDto()
+    {
+      return templateDto;
+    }
+
+    public void setTemplateDto(final TemplateDto templateDto)
+    {
+      this.templateDto = templateDto;
+      for(TemplateDto childTemplate : templateDto.getChildren()) {
+        if(Cell.class.getCanonicalName().equals(childTemplate.getClassName())) {
+          for(Cell c : getCells()) {
+            c.setTemplateDto(childTemplate);
+          }
+        }
+        // FIXME: FooterRow TODO
+      }
+    }
     
   }
 
   
   public class Cell implements PageItem<String> {
+    private TemplateDto templateDto;
     private Row parentRow;
     private Column parentColumn;
     private String value;
@@ -305,6 +330,17 @@ public class SourceProcessorResultTable implements PageItem<String>, Formattable
     {
       return new ArrayList<>(0);
     }
+
+    @Override
+    public TemplateDto getTemplateDto()
+    {
+      return templateDto;
+    }
+
+    public void setTemplateDto(TemplateDto templateDto)
+    {
+      this.templateDto = templateDto;
+    }
   }
   
   @SuppressWarnings("serial")
@@ -352,5 +388,32 @@ public class SourceProcessorResultTable implements PageItem<String>, Formattable
   {
     // TODO Auto-generated method stub
     return null;
+  }
+
+  @Override
+  public TemplateDto getTemplateDto()
+  {
+    return templateDto;
+  }
+
+  /**
+   * Also sets sub-element templates for headerRow and Row
+   * FIXME: Footer not implemented
+   * @param templateDto
+   */
+  public void setTemplateDto(final TemplateDto templateDto)
+  {
+    this.templateDto = templateDto;
+    for(TemplateDto childTemplate : templateDto.getChildren()) {
+      if(HeaderRow.class.getCanonicalName().equals(childTemplate.getClassName())) {
+        getHeader().setTemplateDto(childTemplate);
+      }
+      else if(Row.class.getCanonicalName().equals(childTemplate.getClassName())) {
+        for(Row r : getBody()) {
+          r.setTemplateDto(childTemplate);
+        }
+      }
+      // FIXME: FooterRow TODO
+    }
   }
 }

--- a/src/main/resources/sql/ddl.sql
+++ b/src/main/resources/sql/ddl.sql
@@ -83,9 +83,12 @@ create table APPLICATION_SCHEMAS
 create table TEMPLATE
 (
   ID bigint primary key,
+  PARENT_ID bigint references TEMPLATE(ID),  -- used exclusively for items on a page that are sub-elements and do not have their own tables to represent them, e.g. the ROWS and CELLS within a table.
   CLASS_NAME character varying(32000) not null,
-  SOURCE character varying(32000)
+  SOURCE character varying(32000),
+  MIME_TYPE character varying(255)  -- e.g. text/html, application/json, text/csv etc  
 );
+
 
 /*
  Template instances:
@@ -144,6 +147,7 @@ create table TEMPLATE
 
 */
 
+/* INSTANCES */
 create table PAGE
 (
   ID bigint primary key,
@@ -191,6 +195,7 @@ create table PAGE_PROCESSING_SOURCE
 create table FIELD
 (
   ID bigint primary key,
+  TEMPLATE_ID bigint not null references TEMPLATE(ID),
   NAME character varying(200),
   SOURCE_TYPE_CODE character varying(10) references CODE_SOURCE_TYPE(CODE),
   FIELD_TYPE_CODE character varying(10) references CODE_FIELD_TYPE(CODE),
@@ -213,6 +218,7 @@ create table FIELD_SOURCE
 create table REGION
 (
   ID bigint primary key,
+  TEMPLATE_ID bigint not null references TEMPLATE(ID),
   NAME character varying(1000),
   CODE_REGION_POSITION character varying(10) references CODE_REGION_POSITION(CODE),
   CODE_REGION_TYPE character varying(10) references CODE_REGION_TYPE(CODE),

--- a/src/main/resources/sql/test_dml.sql
+++ b/src/main/resources/sql/test_dml.sql
@@ -10,15 +10,15 @@ insert into application select nextval('application_seq'), 1, 'Test Application'
 --insert into template select nextval('spare_seq'), 'Test Report Template', 'header', 'body', 'footer';
 
 insert into template select nextval('spare_seq'), 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable', '<table>##__DATA__##</table>';
-insert into template select nextval('spare_seq'), 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.HeaderRow', '<tr class="tablerowheader">##__DATA__##</tr>';
-insert into template select nextval('spare_seq'), 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.Row', '<tr class="tablerowdata">##__DATA__##</tr>';
-insert into template select nextval('spare_seq'), 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.Cell', '<td class="tablecell">##__DATA__##</td>';
+insert into template select nextval('spare_seq'), id, 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.HeaderRow', '<tr class="tablerowheader">##__DATA__##</tr>', 'text/html' from template where class_name = 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable';
+insert into template select nextval('spare_seq'), id, 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.Row', '<tr class="tablerowdata">##__DATA__##</tr>', 'text/html' from template where class_name = 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable';
+insert into template select nextval('spare_seq'), id, 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.Cell', '<td class="tablecell">##__DATA__##</td>', 'text/html' from template where class_name = 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable.Row';
 insert into template select nextval('spare_seq'), 'org.awiki.kamikaze.summit.dto.entry.PageDto', '<html><body>##__DATA__##</body></html>';
 insert into template select nextval('spare_seq'), 'org.awiki.kamikaze.summit.dto.entry.RegionDto', '<div class="region">##__DATA__##</div>';
 insert into template select nextval('spare_seq'), 'org.awiki.kamikaze.summit.dto.entry.FieldDto', '<div class="field">##__DATA__##</div>';
 
 
-insert into page (select nextval('page_seq'), id, 'Test Report Page' from template where name = 'Test Report Template');
+insert into page (select nextval('page_seq'), id, 'Test Report Page' from template where class_name = 'org.awiki.kamikaze.summit.dto.entry.PageDto');
 
 insert into application_page (select nextval('spare_seq'), id, (select id from page where name = 'Test Report Page'), 1 from application where name = 'Test Application');
 
@@ -32,7 +32,7 @@ insert into code_region_type values ('Report', 'Report Region', 1, 'dml_report')
 
 insert into code_region_position values ('body1', 'Top most region on template body', 3);
 
-insert into region  (select nextval('region_seq'), 'Test Report Region', 'body1', 'Report', 'text/plain; sql; dml; report');
+insert into region  (select nextval('region_seq'), id, 'Test Report Region', 'body1', 'Report', 'text/plain; sql; dml; report' from template where class_name = 'org.awiki.kamikaze.summit.service.processor.result.SourceProcessorResultTable');
 
 insert into page_region (select nextval('spare_seq'), (select id from page where name = 'Test Report Page'), id, 1 from region where name ='Test Report Region');
 


### PR DESCRIPTION
…o their chosen templates.

Template now has a self-referencing join, as we need to handle sub-template items that link only through their parent template.
pageRenderingServiceImpl will set template on any tables
GenericFormatterService will now use TemplateDto's and does not need to hit the DB again.
Update DDL and some test_dml (untested) with changes as specified above.